### PR TITLE
if mongodump fail it's must be fatal 

### DIFF
--- a/mongodb
+++ b/mongodb
@@ -90,8 +90,8 @@ if [ ! $test ]; then
                 debug $outputdump
                 info "Successfully finished dump of all mongodb databases"
         else
-                warning $outputdump
-                warning "Failed to dumping of mongodb databases"
+                fatal $outputdump
+                fatal "Failed to dumping of mongodb databases"
         fi
 else
         debug "Running backup of mongodb"


### PR DESCRIPTION
i explain :
for example if i stop mongodb service : /etc/init.d/mongodb stop
then i ask ninjabackup to backup mongodb :

Aug 05 22:58:16 Info: >>>> starting action /etc/backup.d/10-action.mongodb (because of --now)
Aug 05 22:58:16 Info: Going to backup mongodb of localhost in /cluster-storage/backups/mongodb
Aug 05 22:58:16 Warning: Failed to dump all mongodb databases
Aug 05 22:58:16 Warning: <<<< finished action /etc/backup.d/10-action.mongodb: WARNING
Aug 05 22:58:16 Info: FINISHED: 1 actions run. 0 fatal. 0 error. 1 warning.

I have only a warning !!!! and nothing is backuped !!!
