### PR TITLE
Fixed bug in backup dir creation and added mongodb user and password options.

### DIFF
--- a/mongodb
+++ b/mongodb
@@ -7,6 +7,8 @@ getconf tar /bin/tar
 getconf mongodump /usr/bin/mongodump
 getconf backupdir /var/backups/mongodb
 getconf dbhost localhost
+getconf mongouser
+getconf mongopass
 getconf vsname
 
 # Decide if the handler should operate on a vserver or on the host.
@@ -33,7 +35,7 @@ fi
 
 # create backup dirs, $vroot will be empty if no vsname was specified
 # and we will instead proceed to operate on the host
-[ -d $vroot$backupdir ] || mkdir -p $root$vbackupdir
+[ -d $vroot$backupdir ] || mkdir -p $vroot$backupdir
 [ -d $vroot$backupdir ] || fatal "Backup directory is '$vroot$backupdir'"
 
 #######################################################################
@@ -41,6 +43,12 @@ fi
 
 if [ ! -f $vroot$mongodump ]; then
         fatal "$vroot$mongodump does not exists"
+fi
+
+if [ "$mongouser" -a "$mongopass" ]
+then
+	info "using $mongouser for authentication"
+	AUTH="-u $mongouser -p $mongopass"
 fi
 
 if [ $usevserver = yes ]
@@ -55,7 +63,7 @@ then
                 fatal "$vroot$backupdir is not writable"
         fi
 
-        execdump="$VSERVER $vsname exec $mongodump -h $dbhost -o $backupdir"
+        execdump="$VSERVER $vsname exec $mongodump -h $dbhost -o $backupdiri $AUTH"
         execrm="$VSERVER $vsname exec rm -rf $backupdir/*"
 else
         if [ ! -d $backupdir ]; then
@@ -66,7 +74,7 @@ else
                 fatal "$backupdir is not writable"
         fi
 
-        execdump="$mongodump -h $dbhost -o $backupdir"
+        execdump="$mongodump -h $dbhost -o $backupdir $AUTH"
         execrm="rm -rf $backupdir/*"
 fi
 

--- a/mongodb.helper
+++ b/mongodb.helper
@@ -28,6 +28,20 @@ mongodb_wizard() {
    result="$REPLY"
    mongodump="mongodump = $result"
 
+   mongouser="# mongouser = <username>"
+   mongopass="# mongopass = <password>"
+   inputBox "$mongodb_title" "Mongo DB User" 
+   [ $? = 1 ] && return;
+   result="$REPLY"
+   if [ $REPLY ]
+   then
+      mongouser="mongouser = $result"
+      inputBox "$mongodb_title" "Mongo DB Password"
+      [ $? = 1 ] && return;
+      result="$REPLY"
+      mongopass="mongopass = $result"
+   fi
+
    inputBox "$mongodb_title" "Directory where backups should be stored?`echo \"\n(Relative to the vserver's root if run in a vserver)\"`" "/var/backups/mongodb"
    [ $? = 1 ] && return;
    result="$REPLY"
@@ -42,6 +56,8 @@ mongodb_wizard() {
    cat > $next_filename <<EOF
 # when = everyday at 5:15
 $mongodump
+$mongouser
+$mongopass
 $backupdir
 $dbhost
 $vsname


### PR DESCRIPTION
I fixed a bug in the handler where the backup directory was created. Somehow the variable names were messed up.

Furthermore I added (optional) mongodb user and password options to the handler and the helper scripts in order to be able to dump database that require authentication.

This is my first try on modifying backupninja handlers or helpers, so if I messed up anything just let me know and I can fix it.
